### PR TITLE
fix: changing image element of one card affects original card it's based on

### DIFF
--- a/backend/Controllers/FileUploadsController.cs
+++ b/backend/Controllers/FileUploadsController.cs
@@ -88,5 +88,11 @@ namespace backend.Controllers
             var replaced = await _fileUploadService.ReplaceCardFaceElementImageFileAsync(formFile, fileName);
             return replaced ? Ok(new { id = fileName }) : BadRequest();
         }
+
+        [HttpPut("card-face-element-image-path/{srcFileName}")]
+        public async Task<ActionResult<string>> ReplaceCardFaceElementImageFilePathAsync(string srcFileName)
+        {
+            return  await _fileUploadService.ReplaceCardFaceElementImageFilePathAsync(srcFileName);
+        }
     }
 }

--- a/backend/Services/Classes/File/FileUploadService.cs
+++ b/backend/Services/Classes/File/FileUploadService.cs
@@ -187,6 +187,33 @@ namespace Services
             await DeleteFileAsync(cardFaceElementImageFilePath, fileName);
         }
 
+        public async Task<string> ReplaceFilePathAsync(string volumePath, string sourceFileName)
+    {
+        string sourceFilePath = Path.Combine(volumePath, sourceFileName);
+
+        if (string.IsNullOrWhiteSpace(sourceFileName))
+            throw new ArgumentException("Source file name cannot be null or empty.", nameof(sourceFileName));
+        if (!File.Exists(sourceFilePath))
+            throw new FileNotFoundException("Source file does not exist.", sourceFileName);
+
+        string destinationFileName = Guid.NewGuid().ToString();
+         string destinationFilePath = Path.Combine(volumePath, destinationFileName);
+
+        // Asynchronously copy the file
+        using (FileStream sourceStream = File.Open(sourceFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+        using (FileStream destinationStream = File.Create(destinationFilePath))
+        {
+            await sourceStream.CopyToAsync(destinationStream);
+        }
+
+        return destinationFilePath;
+    }
+
+        public async Task<string> ReplaceCardFaceElementImageFilePathAsync(string srcFileName)
+        {
+            return await ReplaceFilePathAsync(cardFaceElementImageFilePath, srcFileName);
+        }
+
         // TODO: figure out how to fix this
         /*public void ConvertBlobToFile(byte[] blob, string filePath) {
             try 

--- a/backend/Services/Interfaces/General/File/IFileUploadService.cs
+++ b/backend/Services/Interfaces/General/File/IFileUploadService.cs
@@ -27,5 +27,9 @@ namespace Services
         public Task DeleteCardFaceElementImageFileAsync(string fileName);
         
         /*public void ConvertBlobToFile(byte[] blob, string filePath);*/
+
+        public Task<string> ReplaceFilePathAsync(string volumePath, string sourceFileName);
+    
+        public Task<string> ReplaceCardFaceElementImageFilePathAsync(string srcFileName);
     }
 }

--- a/frontend/src/app/features/card-game-core/services/card-editor-preview.service.ts
+++ b/frontend/src/app/features/card-game-core/services/card-editor-preview.service.ts
@@ -263,7 +263,7 @@ export class CardEditorPreviewService {
       }
       
       let uploadCardFaceImages$ = cardFaceImages.map((formData: FormData) =>
-        this.fileUploadApiService.uploadFile(formData, 'card-face')
+        this.fileUploadApiService.uploadFile$(formData, 'card-face')
       );
   
       // TODO: Replace the fork join with cardFacesFormData
@@ -299,7 +299,7 @@ export class CardEditorPreviewService {
         {
           // NOTE: If you create a card without flipping, then suddenly flip it after and add elements to the card face
           // It's because there's no thumbnail image file path for that face because it never was created
-          return this.fileUploadApiService.uploadFile(formData, 'card-face');
+          return this.fileUploadApiService.uploadFile$(formData, 'card-face');
         }
 
         return this.fileUploadApiService.replaceFile(formData, cardFaceThumbnailFilePath as string, 'card-face');
@@ -429,6 +429,14 @@ export class CardEditorPreviewService {
     // CHECKME: Is this correct?
     let content: string = cardFaceElementPerCardFace.cardFaceElement.cardFaceElementContent;
 
+    let guidPattern: RegExp = /^(?:\{{0,1}(?:[0-9a-fA-F]){8}-(?:[0-9a-fA-F]){4}-(?:[0-9a-fA-F]){4}-(?:[0-9a-fA-F]){4}-(?:[0-9a-fA-F]){12}\}{0,1})$/;
+
+    // NOTE: This means that the element's image was already created
+    // The bug occurs when you create from an already created image, but do not change the image element
+    if (content.match(guidPattern)) {
+      return this.fileUploadApiService.replaceFilePath$(content, 'card-face-element-image');
+    }
+    
     // let dataUrl: string = cardFaceElementPerCardFace.cardFaceElement?.cardFaceElementContent.replace(/^data:image\/\w+;base64,/, '');
 
     // https://stackoverflow.com/questions/11876175/how-to-get-a-file-or-blob-from-an-object-url
@@ -441,7 +449,7 @@ export class CardEditorPreviewService {
         if (!formData) {
           return of({ id: undefined });
         }
-        return this.fileUploadApiService.uploadFile(formData, 'card-face-element-image');
+        return this.fileUploadApiService.uploadFile$(formData, 'card-face-element-image');
       })
     );
   }
@@ -553,10 +561,11 @@ export class CardEditorPreviewService {
                 return of({ id: undefined });
               }
   
+              // CHECKME: Do we put || parseFloat(this.cardEditorCardDto.card.cardId) > 0
               if (!result) {
                 // NOTE: For adding on image elements after updating: upload as new file
                 console.log(`Replace Card Face Element Image: No existing image element`);
-                return this.fileUploadApiService.uploadFile(formData, 'card-face-element-image');
+                return this.fileUploadApiService.uploadFile$(formData, 'card-face-element-image');
               } 
               else {
                 console.log(`Replace Card Face Element Image: Existing image element`);

--- a/frontend/src/app/utils/components/file-upload/file-upload.component.ts
+++ b/frontend/src/app/utils/components/file-upload/file-upload.component.ts
@@ -39,7 +39,7 @@ export class FileUploadComponent {
   // TODO: When we submit the file, we call the API and get the file again
   onSubmit(event: Event) {
     if (this.file) {
-      /*let filePath: ResourceRef<string | undefined> = this.fileUploadApiService.uploadFile(this.file);
+      /*let filePath: ResourceRef<string | undefined> = this.fileUploadApiService.uploadFile$(this.file);
       
       if (filePath !== undefined) 
       {

--- a/frontend/src/app/utils/services/file-upload-api.service.ts
+++ b/frontend/src/app/utils/services/file-upload-api.service.ts
@@ -26,9 +26,18 @@ export class FileUploadApiService {
     }
   }
 
+  replaceFilePath$(fileName: string, type?: string): Observable<{ id: string | undefined; }> {
+    switch (type) {
+      case "card-face-element-image":
+        return this.http.put<{id: string}>(`${this.apiUrl}/card-face-element-image-path/${fileName}`, fileName);
+      default:
+         return this.http.put<{id: string}>(`${this.apiUrl}/card-face-element-image-path/${fileName}`, fileName);
+    }
+  }
+
   // TODO: Do switch statement here
   
-  uploadFile(formData: FormData, type?: string): Observable<{ id: string }> {
+  uploadFile$(formData: FormData, type?: string): Observable<{ id: string }> {
     let headers = new HttpHeaders().set('Content-Type', 'multipart/form-data');
     
     switch (type)


### PR DESCRIPTION
The reason why it was the case was during the upload file, it checks to see if the card face element's content contains image data or the file name. But because there was no logic to handle what happens if there is a file name found, that's why two card face elements of two different images shared a file path.