### PR TITLE
fix: correct scaling for card face on zoom

### DIFF
--- a/frontend/src/app/features/card-game-core/components/card-editor-controls-cards-template-collection/card-editor-controls-cards-template-collection.component.css
+++ b/frontend/src/app/features/card-game-core/components/card-editor-controls-cards-template-collection/card-editor-controls-cards-template-collection.component.css
@@ -3,4 +3,6 @@
     overflow-x: scroll;
     display: flex;
     flex-direction: row;
+    gap: 1rem;
+    padding: 1%;
 }

--- a/frontend/src/app/features/card-game-core/components/card-editor-controls-cards-template-collection/card-editor-controls-cards-template-collection.component.html
+++ b/frontend/src/app/features/card-game-core/components/card-editor-controls-cards-template-collection/card-editor-controls-cards-template-collection.component.html
@@ -1,7 +1,7 @@
 <div class="cec-cards-template-collection">
-    <app-card [card]="new" [title] ="new.cardName" [zoomLevel]="0.75" (click)="onClickCard($event, new.cardId)"/>
+    <app-card [card]="new" [title] ="new.cardName" [cardScale]="0.75" (click)="onClickCard($event, new.cardId)"/>
     @for (card of cards; track card) {
-        <app-card [card]="card" [title]="card.cardName" [zoomLevel]="0.75" (click)="onClickCard($event, card.cardId)"/>
+        <app-card [card]="card" [title]="card.cardName" [cardScale]="0.75" (click)="onClickCard($event, card.cardId)"/>
         <app-card-delete-button [cardId]="card.cardId"/>
     }
 </div>

--- a/frontend/src/app/features/card-game-core/components/card-face/card-face.component.html
+++ b/frontend/src/app/features/card-game-core/components/card-face/card-face.component.html
@@ -1,1 +1,1 @@
-<img *ngIf="image.src" [src]="image.src" />
+<img *ngIf="image.src" [src]="image.src" [style.width.px]="image.width" [style.height.px]="image.height"/>

--- a/frontend/src/app/features/card-game-core/components/card-face/card-face.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card-face/card-face.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, DestroyRef, effect, inject, input, InputSignal, Signal } from '@angular/core';
+import { afterRenderEffect, Component, computed, DestroyRef, effect, inject, Input, input, InputSignal, Signal } from '@angular/core';
 
 import { CardFace } from '../../models/card-face';
 
@@ -13,6 +13,8 @@ import { Subject, takeUntil } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { FileMetadataApiService } from '../../../../utils/services/file-metadata-api.service';
 import { FileMetadataStatus } from '../../../../utils/models/file-metadata';
+import { DndBoardService } from '../../../drag-and-drop/services/dnd-board.service';
+import { getScaledItemRenderDimensions } from '../../../../utils/utils';
 
 // https://medium.com/@niteshdaga000/optimizing-performance-with-memory-caching-in-angular-applications-dad3efeb1f99
 // TODO: When loading in the cards menu, use a hybdrid approach of storing the indices, caching the images in memory, using LRU, and only replacing the images that have changed via checking timestamp
@@ -24,7 +26,7 @@ import { FileMetadataStatus } from '../../../../utils/models/file-metadata';
 })
 export class CardFaceComponent {
   private readonly fileUploadApiService: FileUploadApiService = inject(FileUploadApiService);
-  
+ 
   // TODO: Have the calculation to convert the card face elements here
   cardFaceInput: InputSignal<CardFace | undefined>=  input<CardFace | undefined>({
     cardFaceId: "0",
@@ -42,16 +44,40 @@ export class CardFaceComponent {
     }
   });
 
+  cardFaceScale: InputSignal<number> = input<number>(1);
+
   // TODO: Card face image here
   // https://stackoverflow.com/a/27197907
   private destroyRef: DestroyRef = inject(DestroyRef);
 
+  DEFAULT_BASE_WIDTH: number = 154;
+  DEFAULT_BASE_HEIGHT: number = 215;
+
+  baseDimensions = {
+    width: this.DEFAULT_BASE_WIDTH,
+    height: this.DEFAULT_BASE_HEIGHT
+  }
+
   image= {
     src: '/blank-card-canvas.svg',
-    alt: '',
-    width: 154,
-    height: 215
+    alt: 'Placeholder card face',
+    width: this.baseDimensions.width,
+    height: this.baseDimensions.height
   };
+
+  // TODO: Refactor this, this should not be here?
+  // To be used on DND Board, but should just be general in case?
+  // Here's the problem, if you just use transform scale here, the interactive area's not going to resize, which is going to cause issues with UX
+  setCardFaceImageDimensions(scale: number) {
+    let scaledDimensions: {
+      scaledWidth: number;
+      scaledHeight: number;
+    } = getScaledItemRenderDimensions(this.baseDimensions.width, this.baseDimensions.height, scale); // NOTE: Should this even be in this service? It's just a general scaling function
+
+    // FIXED: It was taking the new width and height then multiplying by that instead. Compounded scaling.
+    this.image.width = scaledDimensions.scaledWidth;
+    this.image.height = scaledDimensions.scaledHeight;
+  }
 
   getCardFaceImageSrc(cardFace: CardFace): Promise<HTMLImageElement | undefined> {
     if (!cardFace.cardFaceThumbnailFileMetadata) {
@@ -109,20 +135,53 @@ export class CardFaceComponent {
       
       if (cardFace !== undefined && parseFloat(cardFace.cardFaceId) !== 0) {
         if (!cardFace.cardFaceThumbnailFileMetadata) {
-          this.image.src = "/blank-card-canvas.svg";
+          this.setPlaceholderCardFace();
           return;
         }
 
         this.getCardFaceImageSrc(cardFace).then((image: HTMLImageElement | undefined) => {
-          if (image === undefined)
+          if (!image) {
             return;
+          }
 
           this.image.src = image.src;
-          this.image.width = image.width;
           this.image.alt = image.alt;
-          this.image.height = image.height;
+
+          this.setBaseDimensions(image.width, image.height);
         })
+
+        // This is indeed necessary, because we might not even be grabbing the card face,
+        // To be frank I can't remember why I wrote this here, shouldn't it just be moved outside of this check?
+        // Probably should use guard clausing instead
+         if (this.shouldScaleCardFace()) {
+           this.setCardFaceImageDimensions(this.cardFaceScale());
+         }
       }
     });
+  }
+
+  shouldScaleCardFace(): boolean {
+    let scale = this.cardFaceScale();
+    return scale !== undefined && scale !== null && scale !== 0 && scale !== 1;
+  }
+
+  setBaseDimensions(baseDimensionWidth: number, baseDimensionHeight: number) {
+    this.baseDimensions.width = baseDimensionWidth;
+    this.baseDimensions.height = baseDimensionHeight;
+    
+    if (this.shouldScaleCardFace()) {
+      this.setCardFaceImageDimensions(this.cardFaceScale());
+      return;
+    }
+
+     this.image.width = this.baseDimensions.width;
+     this.image.height = this.baseDimensions.height;
+  }
+
+  setPlaceholderCardFace() {
+    this.image.src = "/blank-card-canvas.svg";
+    this.image.alt = 'Placeholder card face';
+
+    this.setBaseDimensions(this.DEFAULT_BASE_WIDTH, this.DEFAULT_BASE_HEIGHT);
   }
 }

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.html
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.html
@@ -2,7 +2,8 @@
     <div cdkDrag class="cpr-cdk" [style.left.px]="calculateCardPositionPerRoomScreenPosition(cpr.dndPosition).screenX"
         [style.top.px]="calculateCardPositionPerRoomScreenPosition(cpr.dndPosition).screenY" [style.width]="'fit-content'"
         [style.height]="'fit-content'" (cdkDragStarted)="onDragStarted($event, cpr)" (cdkDragMoved)="onDragMoved($event)"
-        (cdkDragDropped)="onDragDrop($event, cpr)">
-        <app-card [zoomLevel]="cardsZoomLevel" [card]="cpr.card" />
+        (cdkDragDropped)="onDragDrop($event, cpr)"
+        #cardsPositionPerRoom>
+        <app-card [cardScale]="cardsPositionPerRoomScale" [card]="cpr.card" />
     </div>
 }

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, ElementRef, inject, Injectable, input, ViewChild  } from '@angular/core';
+import { AfterViewInit, Component, effect, ElementRef, inject, Injectable, input, QueryList, ViewChild, ViewChildren  } from '@angular/core';
 import { CardPositionPerRoomApiService } from '../../services/card-game-core/card-position-per-room-api.service';
 import { CardEditorCardDto, CardPositionPerRoom } from '../../models/card';
 import { CdkDrag, CdkDragDrop, CdkDragMove, CdkDragStart, DragRef, Point} from '@angular/cdk/drag-drop';
@@ -29,13 +29,15 @@ export class CardPositionPerRoomComponent {
 
   cprs: CardPositionPerRoom[] = [];
 
+  @ViewChildren('cardsPositionPerRoom') cardsPositionPerRoomRef!: QueryList<ElementRef<HTMLDivElement>>;
+
   // NOTE: For rendering only
   unculledCprs: CardPositionPerRoom[] = [];
 
   private snapToGridPosition: {x: number, y: number} = {x: 0, y: 0};
   
   // TODO: Refactor the bloody architecture
-  cardsZoomLevel: number = 1;
+  cardsPositionPerRoomScale: number = 1;
   
   private dragOffset: { x: number; y: number; } = {x: 0, y: 0};
 
@@ -119,7 +121,25 @@ export class CardPositionPerRoomComponent {
   // TODO: Refactor this into the dndBoardService
   private setCardsZoomLevel(): void {
     this.dndBoardService.zoomLevel$.subscribe((zoomLevel: number) => {     
-      this.cardsZoomLevel = zoomLevel;
+      let itemRenderScale: number = this.dndBoardService.getItemRenderScale();
+      
+      if (itemRenderScale !== 0) {
+        this.cardsPositionPerRoomScale = itemRenderScale;
+      }
+
+      // TODO: Set the unculled cpr levels for each
+      /*this.cardsPositionPerRoomRef.forEach((cardPositionPerRoom, index) => {
+        let width = cardPositionPerRoom.nativeElement.offsetWidth;
+        let height = cardPositionPerRoom.nativeElement.offsetHeight;
+
+        let scaledDimensions: {
+          scaledWidth: number;
+          scaledHeight: number;
+        } = this.dndBoardService.getScaledItemRenderDimensions(width, height, this.dndBoardService.getItemRenderScale());
+      
+        cardPositionPerRoom.nativeElement.style.width = scaledDimensions.scaledWidth + 'px';
+        cardPositionPerRoom.nativeElement.style.height = scaledDimensions.scaledHeight + 'px';
+      });*/
     })
   }
   

--- a/frontend/src/app/features/card-game-core/components/card/card.component.html
+++ b/frontend/src/app/features/card-game-core/components/card/card.component.html
@@ -1,6 +1,6 @@
 <!--TODO: Modify this so that the inside of the component for the card, it actually switches between multicard faces-->
-<div [style.transform]="transform()" (contextmenu)="onCardRightClick($event)">
-    <app-card-face [cardFaceInput]="currentCardFace" />
+<div (contextmenu)="onCardRightClick($event)">
+    <app-card-face [cardFaceInput]="currentCardFace" [cardFaceScale]="cardScaleComputed()" #cardFace/>
 </div>
 @if (isDisplayContextMenu)
 {

--- a/frontend/src/app/features/card-game-core/components/card/card.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card/card.component.ts
@@ -1,4 +1,4 @@
-import { Component, Signal, viewChildren, output, input, inject, effect, computed, SimpleChanges, InputSignal, Input, HostListener } from '@angular/core';
+import { Component, Signal, viewChildren, output, input, inject, effect, computed, SimpleChanges, InputSignal, Input, HostListener, ViewChild, ElementRef, AfterViewInit, afterRenderEffect } from '@angular/core';
 
 import { Card } from '../../models/card';
 import { cardFlipAnimation } from './card.animations';
@@ -39,6 +39,8 @@ export class CardComponent {
 
   private rightClickMenuPositionX: number = 0;
   private rightClickMenuPositionY: number = 0;
+
+  @ViewChild('cardFace') cardFaceRef!: CardFaceComponent;
 
   card: InputSignal<Card> = input<Card >({
     cardId: "0",
@@ -96,11 +98,11 @@ export class CardComponent {
 
   actionContextMenuItemsChange = output<ActionContextMenuItem[]>();
 
-  zoomLevel: InputSignal<number> =  input<number>(1);
-  scaleLevel: number = 1;
+  cardScale: InputSignal<number> =  input<number>(1);
+  cardScaleComputed: Signal<number>  = computed(() => this.cardScale());
 
   transform() {
-    return `scale(${this.scaleLevel})`;
+    return `scale(${this.cardScaleComputed()})`;
   }
   
   constructor() {
@@ -111,13 +113,13 @@ export class CardComponent {
       if (card !== undefined) {
         this.loadCardFaces(card);
       }
-
-      let zoomLevel: number | undefined = this.zoomLevel();
-
-      if (zoomLevel !== undefined && zoomLevel !== 0) {
-        this.scaleLevel = zoomLevel;
-      }
     });
+  }
+
+  setCardFaceImageDimensionsOnDndBoard(): void {
+    if (this.cardFaceRef && this.cardScale() && this.cardScale() !== 0) {
+      this.cardFaceRef.setCardFaceImageDimensions(this.cardScale());
+    }
   }
 
   // TODO: Rework this, use cardApiService to get the card face IDs, then use a switch map, pass it into the next then assign the cardFaces

--- a/frontend/src/app/features/drag-and-drop/services/dnd-board.service.ts
+++ b/frontend/src/app/features/drag-and-drop/services/dnd-board.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, HostListener, inject } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { DndPosition } from '../models/dnd-types';
-import { clamp } from '../../../utils/utils';
+import { clamp, getScaledItemRenderDimensions } from '../../../utils/utils';
 @Injectable({
   providedIn: 'root'
 })
@@ -208,22 +208,29 @@ export class DndBoardService {
 
   // Item Position AU: Raw position on virtual board
   // Original: Physical image dimensions
-  getScaledItemRenderData(itemPositionXAU: number, itemPositionYAU: number, originalWidth: number, originalHeight: number): {
+  getScaledItemRenderData(itemPositionXAU: number, itemPositionYAU: number, originalWidth: number, originalHeight: number
+  ): {
     screenX: number;
     screenY: number;
     scaledWidth: number;
     scaledHeight: number;
   } {
-    let { screenX, screenY } = this.aUToScreenCoordinates(itemPositionXAU, itemPositionYAU);
+    let { screenX, screenY } = this.getScaledItemRenderCoordinates(itemPositionXAU, itemPositionYAU);
+    let scale: number = this.getItemRenderScale();
+    let { scaledWidth, scaledHeight } = getScaledItemRenderDimensions(originalWidth, originalHeight, scale);
 
-    let scale = this.getItemRenderScale();
-
-    // Scale width and height
-    let scaledWidth = originalWidth * scale;
-    let scaledHeight = originalHeight * scale;
-  
     return { screenX, screenY, scaledWidth, scaledHeight };
   }
+
+  // Use let scale: number = this.getItemRenderScale();
+
+// Returns the screen coordinates for rendering the item
+getScaledItemRenderCoordinates(itemPositionXAU: number, itemPositionYAU: number): {
+    screenX: number;
+    screenY: number;
+} {
+  return this.aUToScreenCoordinates(itemPositionXAU, itemPositionYAU);
+}
 
   getItemRenderScale() {
     return this.getScaledCellSize() / this.cellSizeScreen;

--- a/frontend/src/app/utils/utils.ts
+++ b/frontend/src/app/utils/utils.ts
@@ -51,3 +51,14 @@ export async function blobToDataURL(blobUrl: string): Promise<string> {
         reader.readAsDataURL(blob);
     });
 }
+
+export function getScaledItemRenderDimensions(
+  originalWidth: number,
+  originalHeight: number,
+  scale: number
+): { scaledWidth: number; scaledHeight: number } {
+  return {
+    scaledWidth: originalWidth * scale,
+    scaledHeight: originalHeight * scale
+  };
+}


### PR DESCRIPTION
refactor: split getScaledItemRenderData into two different functions

refactor: card face now controls its own scaling

fix: blank card face is at right size
fix: aesthetics in cards template collection has correct gap