### PR TITLE
184 card overlapping order priority on board will not be saved

### DIFF
--- a/backend/Models/Bridge/CardPositionPerRoom.cs
+++ b/backend/Models/Bridge/CardPositionPerRoom.cs
@@ -29,6 +29,8 @@ namespace Models.Bridge
         [ForeignKey("CardId")]
         public virtual Card? Card { get; set; }
 
+        public int ZIndex {get; set;} = 1;
+
         public long DndItemId { get; set; }
         [ForeignKey("DndItemId")]
         public virtual DndItem? DndItem { get; set; }
@@ -55,6 +57,8 @@ namespace Models.Bridge
 
         public string CardId { get; set; } = "0";
         public virtual CardDto? Card { get; set; }
+
+        public int ZIndex {get; set;} = 1;
 
         public string DndItemId { get; set; } = "0";
         public virtual DndItemDto? DndItem { get; set; }

--- a/backend/Services/Classes/Card/Data/CardPositionPerRoomService.cs
+++ b/backend/Services/Classes/Card/Data/CardPositionPerRoomService.cs
@@ -195,26 +195,15 @@ namespace Services
                     throw new ArgumentNullException(nameof(nav), "Card Position Per Room - Update nav async: At least one navigational property is null");
                 }
 
-                bool updated = true;
 
-                updated = await _cardService.UpdateAsync(nav.CardId, nav.Card);
-                
-                /*if (!updated)
-                {
-                    return updated;
-                }*/
+                await _cardService.UpdateAsync(nav.CardId, nav.Card);
+                await _dndItemService.UpdateAsync(nav.DndItemId, nav.DndItem);
+                await _dndPositionService.UpdateAsync(nav.DndPositionId, nav.DndPosition);
+                await _dndRotationService.UpdateAsync(nav.DndRotationId, nav.DndRotation);
 
-                updated =  await _dndItemService.UpdateAsync(nav.DndItemId, nav.DndItem);
-
-                /*if (!updated)
-                {
-                    return updated;
-                }*/
-
-                updated =  await _dndPositionService.UpdateAsync(nav.DndPositionId, nav.DndPosition);
-
-                updated =  await _dndRotationService.UpdateAsync(nav.DndRotationId, nav.DndRotation);
-
+                // CHECKME: Is this going to work
+                // TODO: Potentially refactor? We have a property other than just foreign keys here
+                await UpdateAsync(nav.CardPositionPerRoomId, nav);
                 return true;
             }
             catch (DbUpdateConcurrencyException)

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.html
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.html
@@ -3,6 +3,7 @@
         [style.top.px]="calculateCardPositionPerRoomScreenPosition(cpr.dndPosition).y" [style.width]="'fit-content'"
         [style.height]="'fit-content'" (cdkDragStarted)="onDragStarted($event, cpr)" (cdkDragMoved)="onDragMoved($event)"
         [style.transform]="'rotate(' + cpr.dndRotation.degrees + 'deg)'"
+        [style.z-index]="cpr.zIndex"
         (cdkDragDropped)="onDragDrop($event, cpr)"
         (contextmenu)="onCardRightClick($event, cpr.card.cardId)"
         #cardsPositionPerRoom>

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.html
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.html
@@ -1,4 +1,4 @@
-@for (cpr of unculledCprs; track cpr) {
+@for (cpr of unculledCprs; track cpr.cardPositionPerRoomId) {
     <div cdkDrag class="cpr-cdk" [style.left.px]="calculateCardPositionPerRoomScreenPosition(cpr.dndPosition).x"
         [style.top.px]="calculateCardPositionPerRoomScreenPosition(cpr.dndPosition).y" [style.width]="'fit-content'"
         [style.height]="'fit-content'" (cdkDragStarted)="onDragStarted($event, cpr)" (cdkDragMoved)="onDragMoved($event)"
@@ -6,6 +6,7 @@
         [style.z-index]="cpr.zIndex"
         (cdkDragDropped)="onDragDrop($event, cpr)"
         (contextmenu)="onCardRightClick($event, cpr.card.cardId)"
+        [attr.card-position-per-room-id]="cpr.cardPositionPerRoomId"
         #cardsPositionPerRoom>
         <app-card [cardScale]="cardsPositionPerRoomScale" [(card)]="cpr.card" />
     </div>

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
@@ -55,6 +55,10 @@ export class CardPositionPerRoomComponent {
   
   currentContentMenuCpr: CardPositionPerRoom | undefined = undefined;
   
+  private get maxZIndex() {
+    return  Math.max(...this.cprs.map(
+            e => e.zIndex))
+  }
   // TODO: Pass in the cpr here as a parameter to determine whether you can rotate?
   get actionContextMenuItems(): ActionContextMenuItem[] {
     return [
@@ -252,13 +256,8 @@ export class CardPositionPerRoomComponent {
     if (cprToReplace !== undefined) {
       // TODO: Get rid of this whole function
       // console.log(`Cpr to replace: ${JSON.stringify(cprToReplace)}, Updated CPR: ${JSON.stringify(updatedCpr)}`);
-
+      
       Object.assign(cprToReplace, updatedCpr);
-
-      // FIXME: This is a temporary solution, because we're going to have more items than just cards
-      // Basically what's happening here is that we always move the item to the back
-      // Which means in the DOM it'll always be rendered last and therefore higher
-      moveToBack(this.cprs, this.cprs.findIndex(c => c.cardPositionPerRoomId === cprToReplace.cardPositionPerRoomId));
 
       // Force unculled refresh
       this.refreshUnculledCprs();
@@ -300,6 +299,14 @@ export class CardPositionPerRoomComponent {
       });
     }
 
+    private sortOrder() {
+      this.cprs.forEach((cpr: CardPositionPerRoom) => {
+        if (cpr.zIndex > this.cprs.length) {
+          cpr.zIndex = this.cprs.length;
+        }
+      })
+    }
+
   private onDeleteCardEditorCardDto() {
     this.cardGameCoreService.onDeleteCardEditorCardDto$
       .pipe(takeUntilDestroyed())
@@ -308,6 +315,8 @@ export class CardPositionPerRoomComponent {
 
         // Again, this is in case if the user scrolls away from the current card being deleted, for instance
         this.cprs = this.cprs.filter(cpr => cpr.card.cardId !== cardId);
+
+        this.sortOrder();
       });
   }
 
@@ -318,6 +327,9 @@ export class CardPositionPerRoomComponent {
       x: mouseAU.x - item.dndPosition.x,
       y: mouseAU.y - item.dndPosition.y
     };
+
+    // NOTE: Maintain the stacking order
+    this.raiseOverlappedItems(item.dndPosition);
   }
 
   onDragMoved(event: CdkDragMove) {
@@ -421,7 +433,83 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
 
     // console.log(`On drag drop: AU - ${JSON.stringify(item.dndPosition)}), Screen PX - ${JSON.stringify(this.dndBoardService.aUToScreenCoordinates(item.dndPosition.x, item.dndPosition.y))}`);
 
+    // If it's overlapping another item
+    if (this.lowerOverlappedItems(item.dndPosition)) {
+      item.zIndex = clamp(this.maxZIndex + 1, 0, this.cprs.length);
+    }
+
     this.updateCardPositionPerRoom(item);
+  }
+
+  // The reason why this exists is that if we place the item on the same area over 
+  // And over again, the overlapped items don't keep shifting down
+  // Because eventually they would all hit 0th index
+  // We need to keep the stacking order
+  raiseOverlappedItems(dndPosition: DndPosition): boolean {
+    let hasLoweredOverlappedItems: boolean = false;
+
+    // CHECKME: Do we want unculled or all
+    this.unculledCprs.forEach((cpr: CardPositionPerRoom) => {
+      if (!this.isInsideOverlappingItemsBoundary(
+        {x: cpr.dndPosition.x, y: cpr.dndPosition.y},
+        this.getOverlappingItemsBoundary({x: dndPosition.x, y: dndPosition.y}, 50))) // NOTE: Arbitrary number
+        return;
+
+      // We need to do this to update the main cpr list
+      cpr.zIndex = clamp(cpr.zIndex + 1, 0, this.cprs.length);
+      this.updateCardPositionPerRoom(cpr);
+      hasLoweredOverlappedItems = true;
+    })
+
+    return hasLoweredOverlappedItems;
+  }
+
+  lowerOverlappedItems(dndPosition: DndPosition): boolean {
+    let hasLoweredOverlappedItems: boolean = false;
+
+    // CHECKME: Do we want unculled or all
+    this.unculledCprs.forEach((cpr: CardPositionPerRoom) => {
+      if (!this.isInsideOverlappingItemsBoundary(
+        {x: cpr.dndPosition.x, y: cpr.dndPosition.y},
+        this.getOverlappingItemsBoundary({x: dndPosition.x, y: dndPosition.y}, 50))) // NOTE: Arbitrary number
+        return;
+
+      // We need to do this to update the main cpr list
+      cpr.zIndex = clamp(cpr.zIndex - 1, 0, this.cprs.length);
+      this.updateCardPositionPerRoom(cpr);
+      hasLoweredOverlappedItems = true;
+    })
+
+    return hasLoweredOverlappedItems;
+  }
+
+  // TODO: Refactor this, this is temporary overlap check
+  // Here's the thing, what we actually really need is the precise size
+  // Of the card itself, it would just be better to have it so that
+  // If there's an overlap, we just 'hide the card', aka cull it
+  // Especially since there's multiple cards that can be stacked on each other
+  // Does that mean the z-index is unnecessary, I mean what we  can do is just
+  // Have a z-index of -1, if indeed it is negative 1, don't render it?
+  // That means that whenever the card moves, the overlapped card (-1) would have to shift up at least 1 index
+  getOverlappingItemsBoundary(coordinate: Coordinates, distance: number) {
+    return {
+      left: coordinate.x - distance,
+      right: coordinate.x + distance,
+      top: coordinate.y - distance,
+      bottom: coordinate.y + distance
+    }
+  }
+
+  isInsideOverlappingItemsBoundary(
+    coordinate: { x: number; y: number },
+    boundary: { left: number; right: number; top: number; bottom: number }
+  ): boolean {
+    return (
+      coordinate.x >= boundary.left &&
+      coordinate.x <= boundary.right &&
+      coordinate.y >= boundary.top &&
+      coordinate.y <= boundary.bottom
+    );
   }
 
   snapToGrid(gridSize: number, userPointerPosition: Point)

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
@@ -60,6 +60,12 @@ export class CardPositionPerRoomComponent {
     return  Math.max(...this.cprs.map(
             e => e.zIndex))
   }
+
+  // NOTE: Reset it when there's no more cards in the room
+  // Reset the global zIndex counter only if you anticipate integer overflow, 
+  // performance issues, 
+  // or want to keep your zIndex values manageable for debugging and maintenance
+
   // TODO: Pass in the cpr here as a parameter to determine whether you can rotate?
   get actionContextMenuItems(): ActionContextMenuItem[] {
     return [
@@ -216,6 +222,7 @@ export class CardPositionPerRoomComponent {
         if (result !== undefined) {
           this.cprs = result;
           this.refreshUnculledCprs();
+          this.dndBoardService.globalZIndexCounter = Math.max(...this.cprs.map(c => c.zIndex)) + 1;
         }
     });
   }
@@ -272,6 +279,9 @@ export class CardPositionPerRoomComponent {
 
   private updateCardPositionPerRoomOnSave() {
     this.gameRoomService.onSaveGameRoom$.subscribe(() => {
+      // Keeps order clean and predictable, prevents potential overflow
+      this.normaliseZIndexes();
+
       console.log(`Update card position per room on save: ${JSON.stringify(this.cprs)}`);
       
       this.cardPositionPerRoomApiService.updateCardsPositionPerRoom(this.cprs).subscribe((cprs: CardPositionPerRoom[] | undefined) => {
@@ -315,7 +325,9 @@ export class CardPositionPerRoomComponent {
         // Again, this is in case if the user scrolls away from the current card being deleted, for instance
         this.cprs = this.cprs.filter(cpr => cpr.card.cardId !== cardId);
 
-        this.sortOrder();
+        // Reset the counter to prevent integer overflow
+        if (this.cprs.length <= 0) 
+          this.dndBoardService.globalZIndexCounter = 0;
       });
   }
 
@@ -362,8 +374,8 @@ export class CardPositionPerRoomComponent {
 
     let attributes = this.getCardPositionPerRoomOverlappingAttributes(item);
     // NOTE: Maintain the stacking order
-    this.raiseOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions);
-    this.restoreOverlappedCards(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions); // Necessary order otherwise it'll raise the restored overlapped card's z-index
+    // this.raiseOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions);
+    // this.restoreOverlappedCards(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions); // Necessary order otherwise it'll raise the restored overlapped card's z-index
   }
 
   onDragMoved(event: CdkDragMove) {
@@ -470,10 +482,13 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
 
     // If it's overlapping another item
     let attributes = this.getCardPositionPerRoomOverlappingAttributes(item);
+    // this.cullOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions));
 
-    if (this.lowerOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions)) {
+    /*if (this.lowerOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions)) {
       item.zIndex = clamp(this.maxZIndex + 1, 0, this.cprs.length); // We only want to raise the z Index if there is actual overlapping, otherwise what's the point
-    }
+    }*/
+
+    item.zIndex = this.dndBoardService.globalZIndexCounter++;
 
     this.updateCardPositionPerRoom(item);
   }
@@ -553,6 +568,41 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
     this.overlappedCprs.set(currentCpirId, [cpr]);
   }
 
+  cullOverlappedItems(currentCprId: string, coordinates: Coordinates, dimensions: Dimensions) {
+    let toCull: Set<string> = new Set();
+
+    this.unculledCprs.forEach((cpr: CardPositionPerRoom) => {
+      if (cpr.cardPositionPerRoomId === currentCprId) {
+        // Skip the card being moved
+        return;
+      }
+      
+      // TODO: Probably refactor this out of here
+      /****************************************************************** */
+      let attributes = this.getCardPositionPerRoomOverlappingAttributes(cpr);
+
+      if (this.isRectContainedIn(
+        {
+          coordinates: attributes.coordinates,
+          dimensions: attributes.dimensions
+        },
+        {
+          coordinates: coordinates,
+          dimensions: dimensions
+        }
+      )) {
+        // FIXME: Why is it not actually culling these cards
+        this.addOverlappedCpr(currentCprId, cpr);
+        toCull.add(cpr.cardPositionPerRoomId);
+        return;
+      }
+    })
+
+    this.unculledCprs = this.unculledCprs.filter(
+      c => !toCull.has(c.cardPositionPerRoomId)
+    );
+  }
+
   lowerOverlappedItems(currentCprId: string, coordinates: Coordinates, dimensions: Dimensions): boolean {
     let hasLoweredOverlappedItems: boolean = false;
     let toCull: Set<string> = new Set();
@@ -612,6 +662,7 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
     return hasLoweredOverlappedItems;
   }
 
+  // FIXME: Why is it not culling correctly, etc.
   isRectContainedIn(
     innerRect: { coordinates: Coordinates, dimensions: Dimensions },
     outerRect: { coordinates: Coordinates, dimensions: Dimensions }
@@ -622,6 +673,17 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
       innerRect.coordinates.y >= outerRect.coordinates.y &&
       innerRect.coordinates.y + innerRect.dimensions.height <= outerRect.coordinates.y + outerRect.dimensions.height
     );
+  }
+
+  // NOTE: Just to make sure that they all have unique IDs
+  // Because the issue is despite overlapping
+  // They can share the same zIndex, so the order ends up being dependent on the DOM
+  normaliseZIndexes() {
+    // Use all cprs, not just unculled
+    let sorted: CardPositionPerRoom[] = this.cprs.slice().sort((a, b) => a.zIndex - b.zIndex);
+    sorted.forEach((cpr, idx) => cpr.zIndex = idx);
+
+    this.dndBoardService.globalZIndexCounter = sorted.length + 1;
   }
 
 

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
@@ -40,6 +40,7 @@ export class CardPositionPerRoomComponent {
 
   // NOTE: For rendering only
   unculledCprs: CardPositionPerRoom[] = [];
+ private overlappedCprs: Map<string, CardPositionPerRoom[]> = new Map();
 
   private snapToGridPosition: {x: number, y: number} = {x: 0, y: 0};
   
@@ -301,9 +302,7 @@ export class CardPositionPerRoomComponent {
 
     private sortOrder() {
       this.cprs.forEach((cpr: CardPositionPerRoom) => {
-        if (cpr.zIndex > this.cprs.length) {
-          cpr.zIndex = this.cprs.length;
-        }
+        cpr.zIndex = cpr.zIndex - (cpr.zIndex - this.cprs.length); // Again, this is to make sure it's all relative, you're always going to get the same exact difference
       })
     }
 
@@ -320,6 +319,39 @@ export class CardPositionPerRoomComponent {
       });
   }
 
+  private restoreOverlappedCards(currentCprId: string, coordinates: Coordinates, dimensions: Dimensions): void {
+    // NOTE: Just to make sure since we're 
+    let overlapped: CardPositionPerRoom[] | undefined = this.overlappedCprs.get(currentCprId);
+
+    if (!overlapped)
+      return;
+
+    let isUnculled: boolean = false;
+
+    overlapped.forEach((cpr: CardPositionPerRoom,) => {
+      let attributes = this.getCardPositionPerRoomOverlappingAttributes(cpr);
+
+      if (!this.isRectContainedIn(
+        {
+          coordinates: attributes.coordinates,
+          dimensions: attributes.dimensions
+        },
+        {
+          coordinates: coordinates,
+          dimensions: dimensions
+        }
+      ))
+        return;
+
+      // TODO: We need to uncull this whenever you move the card    
+      this.unculledCprs.push(cpr);
+      isUnculled = true;
+    });
+
+    if (isUnculled)
+      this.overlappedCprs.delete(currentCprId);
+  }
+
   onDragStarted(event: CdkDragStart<any>, item: CardPositionPerRoom) {
     let mouseAU = this.dndBoardService.getMouseAUCoordinates();
     // NOTE: This is because unless you click at the top left of the item, there'll always be an offset
@@ -328,8 +360,10 @@ export class CardPositionPerRoomComponent {
       y: mouseAU.y - item.dndPosition.y
     };
 
+    let attributes = this.getCardPositionPerRoomOverlappingAttributes(item);
     // NOTE: Maintain the stacking order
-    this.raiseOverlappedItems(item.dndPosition);
+    this.raiseOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions);
+    this.restoreOverlappedCards(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions); // Necessary order otherwise it'll raise the restored overlapped card's z-index
   }
 
   onDragMoved(event: CdkDragMove) {
@@ -342,22 +376,22 @@ export class CardPositionPerRoomComponent {
    /* 
    This matches your expected input.
 
-Coordinate Math
-Your function subtracts the board's bounding rect (rect.left, rect.top) from the pointer position, then adds scroll, then converts to AU.
+      Coordinate Math
+      Your function subtracts the board's bounding rect (rect.left, rect.top) from the pointer position, then adds scroll, then converts to AU.
 
-This is the correct approach if your board is scrolled and zoomed, and your camera is managed via scroll position (not a separate camera variable).
+      This is the correct approach if your board is scrolled and zoomed, and your camera is managed via scroll position (not a separate camera variable).
 
-Caveats
-Make sure dndBoardElement is the actual scrollable board element.
+      Caveats
+      Make sure dndBoardElement is the actual scrollable board element.
 
-If your camera is managed by scroll, do not add cameraX/cameraY elsewhere in the conversion.
+      If your camera is managed by scroll, do not add cameraX/cameraY elsewhere in the conversion.
 
-If you programmatically pan (not just scroll), you may need to adjust your math as previously discussed.
+      If you programmatically pan (not just scroll), you may need to adjust your math as previously discussed.
 
-Summary Table
-Usage Scenario	Will it work?	Notes
-Board scrolls to pan	Yes	Your function is correct.
-Board pans programmatically (cameraX/Y)	Only if you adjust math	You must factor in cameraX/Y instead of scrollLeft/scrollTop.
+      Summary Table
+      Usage Scenario	Will it work?	Notes
+      Board scrolls to pan	Yes	Your function is correct.
+      Board pans programmatically (cameraX/Y)	Only if you adjust math	You must factor in cameraX/Y instead of scrollLeft/scrollTop.
    */
 
     if (snapToGrid) {
@@ -433,9 +467,12 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
 
     // console.log(`On drag drop: AU - ${JSON.stringify(item.dndPosition)}), Screen PX - ${JSON.stringify(this.dndBoardService.aUToScreenCoordinates(item.dndPosition.x, item.dndPosition.y))}`);
 
+
     // If it's overlapping another item
-    if (this.lowerOverlappedItems(item.dndPosition)) {
-      item.zIndex = clamp(this.maxZIndex + 1, 0, this.cprs.length);
+    let attributes = this.getCardPositionPerRoomOverlappingAttributes(item);
+
+    if (this.lowerOverlappedItems(item.cardPositionPerRoomId, attributes.coordinates, attributes.dimensions)) {
+      item.zIndex = clamp(this.maxZIndex + 1, 0, this.cprs.length); // We only want to raise the z Index if there is actual overlapping, otherwise what's the point
     }
 
     this.updateCardPositionPerRoom(item);
@@ -445,43 +482,148 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
   // And over again, the overlapped items don't keep shifting down
   // Because eventually they would all hit 0th index
   // We need to keep the stacking order
-  raiseOverlappedItems(dndPosition: DndPosition): boolean {
-    let hasLoweredOverlappedItems: boolean = false;
+  raiseOverlappedItems(currentCprId: string, coordinates: Coordinates, dimensions: Dimensions): boolean {
+    let hasRaisedOverlappedItems: boolean = false;
 
     // CHECKME: Do we want unculled or all
     this.unculledCprs.forEach((cpr: CardPositionPerRoom) => {
-      if (!this.isInsideOverlappingItemsBoundary(
-        {x: cpr.dndPosition.x, y: cpr.dndPosition.y},
-        this.getOverlappingItemsBoundary({x: dndPosition.x, y: dndPosition.y}, 50))) // NOTE: Arbitrary number
+      if (cpr.cardPositionPerRoomId === currentCprId) {
+        // Skip the card being moved
         return;
+      }
+  
+      let attributes = this.getCardPositionPerRoomOverlappingAttributes(cpr);
 
+      if (!this.isPartialOverlap(
+        {
+          coordinates: coordinates,
+          dimensions: dimensions
+        },
+        {
+          coordinates: attributes.coordinates,
+          dimensions: attributes.dimensions
+        }
+      )) {
+        return
+      }
+
+      // CHECKME: If there's multiple items of the same z index, is this going to be an issue
       // We need to do this to update the main cpr list
       cpr.zIndex = clamp(cpr.zIndex + 1, 0, this.cprs.length);
       this.updateCardPositionPerRoom(cpr);
-      hasLoweredOverlappedItems = true;
+      hasRaisedOverlappedItems = true;
     })
 
-    return hasLoweredOverlappedItems;
+    return hasRaisedOverlappedItems;
   }
 
-  lowerOverlappedItems(dndPosition: DndPosition): boolean {
+  getCardPositionPerRoomOverlappingAttributes(item: CardPositionPerRoom): {
+    coordinates: Coordinates;
+    dimensions: Dimensions;
+} {
+    let coordinates: Coordinates = {
+      x: item.dndPosition.x,
+      y: item.dndPosition.y
+    };
+
+    let rect: DOMRect | null = this.getCardPositionPerRoomRectById(item.cardPositionPerRoomId);
+
+    if (!rect)
+      throw new Error("Card position per room can't get back its own width and height!?");
+
+    let dimensions: Dimensions = {
+      width: rect.width,
+      height: rect.height
+    };
+
+    return {
+      coordinates,
+      dimensions
+    };
+  }
+
+  addOverlappedCpr(currentCpirId: string, cpr: CardPositionPerRoom) {
+    let overlapped: CardPositionPerRoom[] | undefined = this.overlappedCprs.get(currentCpirId);
+
+    if (overlapped) {
+      overlapped.push(cpr);
+      return;
+    }
+    
+    this.overlappedCprs.set(currentCpirId, [cpr]);
+  }
+
+  lowerOverlappedItems(currentCprId: string, coordinates: Coordinates, dimensions: Dimensions): boolean {
     let hasLoweredOverlappedItems: boolean = false;
+    let toCull: Set<string> = new Set();
 
     // CHECKME: Do we want unculled or all
     this.unculledCprs.forEach((cpr: CardPositionPerRoom) => {
-      if (!this.isInsideOverlappingItemsBoundary(
-        {x: cpr.dndPosition.x, y: cpr.dndPosition.y},
-        this.getOverlappingItemsBoundary({x: dndPosition.x, y: dndPosition.y}, 50))) // NOTE: Arbitrary number
+      if (cpr.cardPositionPerRoomId === currentCprId) {
+        // Skip the card being moved
         return;
+      }
+      
+      // TODO: Probably refactor this out of here
+      /****************************************************************** */
+      let attributes = this.getCardPositionPerRoomOverlappingAttributes(cpr);
 
+      if (this.isRectContainedIn(
+        {
+          coordinates: attributes.coordinates,
+          dimensions: attributes.dimensions
+        },
+        {
+          coordinates: coordinates,
+          dimensions: dimensions
+        }
+      )) {
+        // TODO: We need to uncull this whenever you move the card
+        this.addOverlappedCpr(currentCprId, cpr);
+        toCull.add(cpr.cardPositionPerRoomId);
+        return;
+      }
+      /********************************************************/
+
+      if (!this.isPartialOverlap(
+        {
+          coordinates: coordinates,
+          dimensions: dimensions
+        },
+        {
+          coordinates: attributes.coordinates,
+          dimensions: attributes.dimensions
+        }
+      )) {
+        return;
+      }
+
+      // CHECKME: If there's multiple items of the same z index, is this going to be an issue
       // We need to do this to update the main cpr list
       cpr.zIndex = clamp(cpr.zIndex - 1, 0, this.cprs.length);
       this.updateCardPositionPerRoom(cpr);
       hasLoweredOverlappedItems = true;
     })
 
+    this.unculledCprs = this.unculledCprs.filter(
+      c => !toCull.has(c.cardPositionPerRoomId)
+    );
+
     return hasLoweredOverlappedItems;
   }
+
+  isRectContainedIn(
+    innerRect: { coordinates: Coordinates, dimensions: Dimensions },
+    outerRect: { coordinates: Coordinates, dimensions: Dimensions }
+  ): boolean {
+    return (
+      innerRect.coordinates.x >= outerRect.coordinates.x &&
+      innerRect.coordinates.x + innerRect.dimensions.width <= outerRect.coordinates.x + outerRect.dimensions.width &&
+      innerRect.coordinates.y >= outerRect.coordinates.y &&
+      innerRect.coordinates.y + innerRect.dimensions.height <= outerRect.coordinates.y + outerRect.dimensions.height
+    );
+  }
+
 
   // TODO: Refactor this, this is temporary overlap check
   // Here's the thing, what we actually really need is the precise size
@@ -491,6 +633,8 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
   // Does that mean the z-index is unnecessary, I mean what we  can do is just
   // Have a z-index of -1, if indeed it is negative 1, don't render it?
   // That means that whenever the card moves, the overlapped card (-1) would have to shift up at least 1 index
+  
+  /******************** PARTIAL OVERLAP*************************/
   getOverlappingItemsBoundary(coordinate: Coordinates, distance: number) {
     return {
       left: coordinate.x - distance,
@@ -500,7 +644,7 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
     }
   }
 
-  isInsideOverlappingItemsBoundary(
+  isInBoundary(
     coordinate: { x: number; y: number },
     boundary: { left: number; right: number; top: number; bottom: number }
   ): boolean {
@@ -511,6 +655,26 @@ The updateMouseAUCoordinatesFromScreen() method converts screen to AU coordinate
       coordinate.y <= boundary.bottom
     );
   }
+
+ isPartialOverlap(
+  rect1: { coordinates: Coordinates, dimensions: Dimensions },
+  rect2: { coordinates: Coordinates, dimensions: Dimensions }
+): boolean {
+  return (
+    rect1.coordinates.x < rect2.coordinates.x + rect2.dimensions.width &&
+    rect1.coordinates.x + rect1.dimensions.width > rect2.coordinates.x &&
+    rect1.coordinates.y < rect2.coordinates.y + rect2.dimensions.height &&
+    rect1.coordinates.y + rect1.dimensions.height > rect2.coordinates.y
+  );
+}
+
+getCardPositionPerRoomRectById(cardPositionPerRoomId: string): DOMRect | null {
+  let element: ElementRef<HTMLDivElement> | undefined = this.cardsPositionPerRoomRef.find(ref =>
+    ref.nativeElement.getAttribute('card-position-per-room-id') === cardPositionPerRoomId
+  );
+  
+  return element ? element.nativeElement.getBoundingClientRect() : null;
+}
 
   snapToGrid(gridSize: number, userPointerPosition: Point)
   {

--- a/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
+++ b/frontend/src/app/features/card-game-core/components/card-position-per-room/card-position-per-room.component.ts
@@ -790,7 +790,8 @@ getCardPositionPerRoomRectById(cardPositionPerRoomId: string): DOMRect | null {
     return {
       position: 'absolute',
       left: `${this.contextMenuPosition.x}px`,
-      top: `${this.contextMenuPosition.y}px`
+      top: `${this.contextMenuPosition.y}px`,
+      zIndex: this.dndBoardService.globalZIndexCounter // FIXED: Context menu can be behind the item that it's clicked on
     }
   }
 

--- a/frontend/src/app/features/card-game-core/components/cards-collection/cards-collection.component.ts
+++ b/frontend/src/app/features/card-game-core/components/cards-collection/cards-collection.component.ts
@@ -229,7 +229,9 @@ export class CardsCollectionComponent {
                 gameRoomId: "1", // FIXME: Replace this with getting the actual current game room
                 autosaveInterval: 30000
               },
-              zIndex: this.dndBoardService.globalZIndexCounter++
+              zIndex: isFinite(this.dndBoardService.globalZIndexCounter)
+                ? this.dndBoardService.globalZIndexCounter++
+                : (this.dndBoardService.globalZIndexCounter = 1, 0)
             };
 
             this.createCardPositionPerRoom(cpr);

--- a/frontend/src/app/features/card-game-core/components/cards-collection/cards-collection.component.ts
+++ b/frontend/src/app/features/card-game-core/components/cards-collection/cards-collection.component.ts
@@ -229,7 +229,7 @@ export class CardsCollectionComponent {
                 gameRoomId: "1", // FIXME: Replace this with getting the actual current game room
                 autosaveInterval: 30000
               },
-              zIndex: 0
+              zIndex: this.dndBoardService.globalZIndexCounter++
             };
 
             this.createCardPositionPerRoom(cpr);

--- a/frontend/src/app/features/card-game-core/components/cards-collection/cards-collection.component.ts
+++ b/frontend/src/app/features/card-game-core/components/cards-collection/cards-collection.component.ts
@@ -229,6 +229,7 @@ export class CardsCollectionComponent {
                 gameRoomId: "1", // FIXME: Replace this with getting the actual current game room
                 autosaveInterval: 30000
               },
+              zIndex: 0
             };
 
             this.createCardPositionPerRoom(cpr);

--- a/frontend/src/app/features/card-game-core/models/card.ts
+++ b/frontend/src/app/features/card-game-core/models/card.ts
@@ -25,6 +25,7 @@ export interface CardEditorCardDto {
 export interface CardPositionPerRoom {
     cardPositionPerRoomId: string;
     card: Card;
+    zIndex: number;
     dndItem: DndItem;
     dndPosition: DndPosition;
     dndRotation: DndRotation;

--- a/frontend/src/app/features/card-game-core/services/card-game-core/card-position-per-room.service.ts
+++ b/frontend/src/app/features/card-game-core/services/card-game-core/card-position-per-room.service.ts
@@ -36,8 +36,7 @@ export class CardPositionPerRoomService {
     });
   }
 
-  updateCardPositionPerRoom(newCpr: CardPositionPerRoom) {
-
+  updateCardPositionPerRoom(cpr: CardPositionPerRoom) {
   }
 
   deleteCardPositionPerRoom(id: string) {

--- a/frontend/src/app/features/card-game-core/utils/card-game-core.utils.ts
+++ b/frontend/src/app/features/card-game-core/utils/card-game-core.utils.ts
@@ -46,6 +46,7 @@ export function isCardPositionPerRoom(obj: any): obj is CardPositionPerRoom {
     return obj
         && typeof obj === 'object'
         && 'card' in obj
+        && 'zIndex' in obj
         && 'dndItem' in obj
         && 'dndPosition' in obj
         && 'gameRoom' in obj

--- a/frontend/src/app/features/drag-and-drop/services/dnd-board.service.ts
+++ b/frontend/src/app/features/drag-and-drop/services/dnd-board.service.ts
@@ -52,6 +52,9 @@ export class DndBoardService {
   // Angujlar Unit
   // NOTE: If 1 is the scale we're starting at, it makes sense that you can't zoom out further than that 
 
+  // TODO: Refactor this, probably use this for all items on board
+  globalZIndexCounter: number = 0;
+
   private onShowAllItems$$: Subject<void> = new Subject<void>();
   onShowAllItems$: Observable<void> = this.onShowAllItems$$.asObservable();
 


### PR DESCRIPTION
There's actually a major issue right now, for some reason when dragging a card around, it doesn't matter whether the overlapping state or not, it just automatically shifts the previously moved card down in the stacking order. Furthermore, culling fully overlapped cards aren't working.